### PR TITLE
ci: require PRs for spec updates; cut releases on merge

### DIFF
--- a/.github/workflows/release-on-spec.yml
+++ b/.github/workflows/release-on-spec.yml
@@ -1,0 +1,52 @@
+name: Release on spec change
+
+# Fires when a spec bump lands on main (i.e. a spec-update PR is merged).
+# Cuts a GitHub release with the new openapi.json and notes describing the
+# tool changes. Release creation lives here — not in update-spec — because
+# main is protected and all changes arrive via merged PRs.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "MEALIE_VERSION"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-on-spec
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 2   # need the previous commit to diff the spec
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Cut release for this Mealie version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VER="$(cat MEALIE_VERSION)"
+          DATE="$(date -u +%Y-%m-%d)"
+          TAG="spec-${VER}-${DATE}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — nothing to do."
+            exit 0
+          fi
+
+          git show HEAD~1:openapi.json > /tmp/old-spec.json 2>/dev/null || echo '{}' > /tmp/old-spec.json
+          python scripts/spec_diff.py /tmp/old-spec.json openapi.json > /tmp/notes.md
+          echo "----- release notes -----"; cat /tmp/notes.md
+
+          gh release create "$TAG" openapi.json \
+            --title "Mealie ${VER} — ${DATE}" \
+            --notes-file /tmp/notes.md

--- a/.github/workflows/update-spec.yml
+++ b/.github/workflows/update-spec.yml
@@ -19,6 +19,7 @@ env:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: update-spec
@@ -65,7 +66,7 @@ jobs:
           curl -fsSL http://localhost:9925/openapi.json -o openapi.json
           python scripts/gen_tools.py   # normalizes + pretty-writes openapi.json
 
-      - name: Commit + release if the spec changed
+      - name: Open a PR if the spec changed
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -78,19 +79,22 @@ jobs:
           TOOLS="$(python -c "import json;from naming import build_names;print(len(build_names(json.load(open('openapi.json')))))")"
           python scripts/set_version.py "$MEALIE_VERSION" "$DATE" "$TOOLS"
           python scripts/spec_diff.py /tmp/old-spec.json openapi.json > /tmp/notes.md
-          echo "----- release notes -----"; cat /tmp/notes.md
+          echo "----- proposed change -----"; cat /tmp/notes.md
 
+          BRANCH="bot/spec-${MEALIE_VERSION}-${DATE}"
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
           git add -A
           git commit -m "chore: sync Mealie OpenAPI spec (${MEALIE_VERSION})"
-          git push
+          git push -f origin "$BRANCH"
 
-          TAG="spec-${MEALIE_VERSION}-${DATE}"
-          gh release create "$TAG" openapi.json \
-            --title "Mealie ${MEALIE_VERSION} — ${DATE}" \
-            --notes-file /tmp/notes.md \
-            --target "$(git rev-parse HEAD)"
+          # Open the PR, or refresh its body if one is already open for this branch.
+          # main is protected — the release is cut on merge by release-on-spec.yml.
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: sync Mealie OpenAPI spec (${MEALIE_VERSION})" \
+            --body-file /tmp/notes.md \
+          || gh pr edit "$BRANCH" --body-file /tmp/notes.md
 
       - name: Stop Mealie
         if: always()

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ FastMCP disambiguates the path parameter with a `__path` suffix (`slug__path`).
 image, reads its real version from `/api/app/about`
 ([`MEALIE_VERSION`](./MEALIE_VERSION)), pulls `/openapi.json`, regenerates
 [TOOLS.md](./TOOLS.md) + counts, and — **only when the spec actually changed** —
-bumps the version, commits, and cuts a
+bumps the version and **opens a pull request** (main is protected, so every
+change lands via PR). When that PR merges,
+[`release-on-spec`](.github/workflows/release-on-spec.yml) cuts a
 [release](https://github.com/djwmarcx/better-mealie-mcp/releases) (spec attached,
 notes listing added/removed tools). Volatile server-clock defaults are stripped
 so an unchanged run is a true no-op.


### PR DESCRIPTION
Switches the nightly spec bot to open PRs instead of pushing to main, adds a release-on-merge workflow, and documents the PR-based flow. Landing this via PR validates the new branch protection.