### PR TITLE
chore: require Python 3.14+

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p>
   <img src="https://img.shields.io/badge/tools-259-blue" alt="259 tools">
   <a href="https://github.com/jlowin/fastmcp"><img src="https://img.shields.io/badge/Built%20with-FastMCP-purple" alt="Built with FastMCP"></a>
-  <img src="https://img.shields.io/badge/python-3.13%2B-blue" alt="Python 3.13+">
+  <img src="https://img.shields.io/badge/python-3.14%2B-blue" alt="Python 3.14+">
   <img src="https://img.shields.io/badge/Mealie-v3.20.1-brightgreen" alt="Mealie v3.20.1">
 </p>
 <p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "better-mealie-mcp"
 version = "3.20.1"   # mirrors the targeted Mealie version (see MEALIE_VERSION)
 description = "MCP server exposing every Mealie API endpoint (259 tools) via FastMCP"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 dependencies = [
     "fastmcp>=2.10",
     "httpx>=0.27",


### PR DESCRIPTION
Aligns the README Python badge and requires-python with the 3.14 move Renovate already applied to .python-version and the workflows.