### PR TITLE
chore: auto-maintain tool count, de-hardcode prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <em>An MCP server exposing <strong>every</strong> <a href="https://mealie.io">Mealie</a> API endpoint —<br>
-all 259 operations, none excluded. Manage recipes, meal plans, shopping lists,<br>
+all 250+ operations, none excluded. Manage recipes, meal plans, shopping lists,<br>
 households and more from any AI assistant, in natural language.</em>
 
 </div>
@@ -131,7 +131,7 @@ FastMCP disambiguates the path parameter with a `__path` suffix (`slug__path`).
 
 ## 📝 Notes
 
-- **259 tools is a lot of idle context.** Most clients handle it, but if yours
+- **Exposing every endpoint is a lot of tools — a lot of idle context.** Most clients handle it, but if yours
   caps tool counts or you want a leaner context, use FastMCP's tool-search or
   filter by tag — ask and it can be wired in.
 ### Versioning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "better-mealie-mcp"
 version = "3.20.1"   # mirrors the targeted Mealie version (see MEALIE_VERSION)
-description = "MCP server exposing every Mealie API endpoint (259 tools) via FastMCP"
+description = "MCP server exposing every Mealie API endpoint via FastMCP"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [

--- a/scripts/gen_tools.py
+++ b/scripts/gen_tools.py
@@ -58,11 +58,30 @@ def render_tools(spec: dict, names: dict[str, str]) -> tuple[str, int]:
     return "\n".join(lines), total
 
 
-def old_count() -> int | None:
-    if not TOOLS.exists():
-        return None
-    m = re.search(r"\*\*(\d+) tools\*\*", TOOLS.read_text())
-    return int(m.group(1)) if m else None
+def sync_counts(total: int) -> None:
+    """Point every tool-count badge at `total`.
+
+    Count-agnostic: matches the badge/label shape, not a specific number, so it
+    stays correct forever and never needs to know the previous count. The number
+    lives only in these generated/badge spots — prose says "every endpoint".
+    """
+    n = str(total)
+    edits = [
+        (README, [
+            (r"(badge/tools-)\d+(-)", rf"\g<1>{n}\g<2>"),       # shields badge
+            (r'(alt=")\d+( tools")', rf"\g<1>{n}\g<2>"),        # badge alt text
+        ]),
+        (WIZARD, [
+            (r"(<b>)\d+(</b>&nbsp;tools)", rf"\g<1>{n}\g<2>"),  # header chip
+        ]),
+    ]
+    for path, subs in edits:
+        if not path.exists():
+            continue
+        text = path.read_text()
+        for pattern, repl in subs:
+            text = re.sub(pattern, repl, text)
+        path.write_text(text)
 
 
 def main() -> int:
@@ -75,16 +94,10 @@ def main() -> int:
         f.write("\n")
 
     names = build_names(spec)
-    prev = old_count()
     text, total = render_tools(spec, names)
     TOOLS.write_text(text)
-    print(f"TOOLS.md: {total} tools (was {prev})")
-
-    if prev is not None and prev != total:
-        for f in (README, WIZARD):
-            if f.exists():
-                f.write_text(re.sub(rf"\b{prev}\b", str(total), f.read_text()))
-        print(f"Updated tool count {prev} -> {total} in README.md, setup-wizard.html")
+    sync_counts(total)
+    print(f"TOOLS.md + badges synced to {total} tools")
     return 0
 
 


### PR DESCRIPTION
Drops the literal 259 from README prose + pyproject description. The count now lives only in generated/badge spots synced by a count-agnostic `sync_counts()` in gen_tools.py, so it self-updates on each spec change. (uv.lock 3.14 regen intentionally left out to keep this focused.)