### PR TITLE
refactor: standalone setup wizard (no build-time wrapping)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,17 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Wrap the wizard into a standalone index.html
+      - name: Assemble the site
         run: |
           mkdir -p _site
-          {
-            printf '%s\n' '<!doctype html>' '<html lang="en">' '<head>' \
-              '<meta charset="utf-8">' \
-              '<meta name="viewport" content="width=device-width, initial-scale=1">' \
-              '</head>' '<body>'
-            cat setup-wizard.html
-            printf '%s\n' '</body>' '</html>'
-          } > _site/index.html
+          cp setup-wizard.html _site/index.html   # standalone document, served as-is
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ wheels/
 
 # Secrets
 .env
-
-# Generated local build of the setup wizard (see setup-wizard.html)
-setup-wizard.local.html

--- a/setup-wizard.html
+++ b/setup-wizard.html
@@ -1,3 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Better Mealie MCP · Setup Wizard</title>
 <style>
   :root {
@@ -184,6 +189,8 @@
 
   @media (prefers-reduced-motion: reduce){ *{ transition:none !important; } details.docker summary .chev{ transition:none; } }
 </style>
+</head>
+<body>
 
 <div class="wrap">
   <header>
@@ -546,3 +553,6 @@
   syncClient(); syncAuth(); render();
 })();
 </script>
+
+</body>
+</html>


### PR DESCRIPTION
setup-wizard.html is now a complete HTML document — opens directly and serves as-is. Pages build reduced to a plain copy. Removes the partial-HTML + wrap weirdness.