### PR TITLE
fix(ci): install deps in update-spec (nightly was failing)

### DIFF
--- a/.github/workflows/update-spec.yml
+++ b/.github/workflows/update-spec.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Install project (gen_tools needs fastmcp + httpx to measure costs)
+        run: pip install .
+
       - name: Resolve + validate the Mealie tag
         env:
           INPUT_TAG: ${{ github.event.inputs.mealie_tag }}


### PR DESCRIPTION
The nightly **Update Mealie OpenAPI spec** cron has been failing (Jul 11 & 12) with:

```
scripts/gen_tools.py line 103, in context_costs
ModuleNotFoundError: No module named 'httpx'
```

**Cause:** `gen_tools.py` gained `context_costs()` (PR #16, for the wizard's token estimates), which imports `fastmcp` + `httpx`. But `update-spec.yml` runs `python scripts/gen_tools.py` with only `setup-python` and never installs the project deps. It used to be pure-stdlib, so it worked before.

**Fix:** add `pip install .` before the gen_tools step.

Verified in a clean venv: `pip install .` then `python scripts/gen_tools.py` → exit 0, 259 tools synced. No spec change occurred (still v3.20.1), so no data was lost — just the workflow erroring.