### PR TITLE
style(wizard): pot emoji header logo

### DIFF
--- a/setup-wizard.html
+++ b/setup-wizard.html
@@ -58,7 +58,7 @@
 
   /* ---- header ---- */
   header { display:flex; align-items:center; gap:16px; flex-wrap:wrap; }
-  .mark { width:46px; height:46px; flex:none; color:var(--basil); }
+  .mark { flex:none; font-size:40px; line-height:1; }
   .title h1 { font-size:clamp(1.5rem,3.4vw,2.15rem); margin:0; letter-spacing:-.02em; font-weight:660; text-wrap:balance; }
   .title p { margin:2px 0 0; color:var(--muted); font-size:.98rem; }
   .badges { margin-left:auto; display:flex; gap:8px; flex-wrap:wrap; }
@@ -348,13 +348,7 @@
 
 <div class="wrap">
   <header>
-    <svg class="mark" viewBox="0 0 48 48" fill="none" aria-hidden="true">
-      <path d="M9 21h30a0 0 0 0 1 0 0 15 15 0 0 1-15 15 15 15 0 0 1-15-15 0 0 0 0 1 0 0Z" fill="currentColor" opacity=".16"/>
-      <path d="M8 20.5h32M11 22a13 13 0 0 0 26 0" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
-      <path d="M6.5 20.5h35" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
-      <path d="M18 12c0-2.2 1.4-3 1.4-4.6C19.4 5.7 18 5 18 5M24 12c0-2.4 1.6-3.2 1.6-5C25.6 5 24 4.2 24 4.2M30 12c0-2.2 1.4-3 1.4-4.6C31.4 5.7 30 5 30 5"
-        stroke="currentColor" stroke-width="2" stroke-linecap="round" opacity=".7"/>
-    </svg>
+    <span class="mark" role="img" aria-label="Pot of food">🍲</span>
     <div class="title">
       <h1>Better Mealie MCP · Setup Wizard</h1>
       <p>Point any AI client at your Mealie. Pick, fill, copy.</p>


### PR DESCRIPTION
Swaps the hand-drawn pot SVG in the wizard header for the real 🍲 emoji (matches the favicon/messaging). Sized at 40px.