### PR TITLE
fix(ci): one spec PR per Mealie version, not per night

### DIFF
--- a/.github/workflows/update-spec.yml
+++ b/.github/workflows/update-spec.yml
@@ -84,7 +84,9 @@ jobs:
           python scripts/spec_diff.py /tmp/old-spec.json openapi.json > /tmp/notes.md
           echo "----- proposed change -----"; cat /tmp/notes.md
 
-          BRANCH="bot/spec-${MEALIE_VERSION}-${DATE}"
+          # One branch per Mealie version, no date: a stale PR gets force-pushed
+          # and refreshed instead of piling up a new PR every night.
+          BRANCH="bot/spec-${MEALIE_VERSION}"
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH"


### PR DESCRIPTION
The bot branch name embedded the run date (`bot/spec-${VERSION}-${DATE}`), so every nightly run pushed a new branch and opened a **new PR for the same spec version** — see #27 and #28, both "sync Mealie OpenAPI spec (v3.21.0)" one day apart. The intended dedup path (`gh pr create || gh pr edit "$BRANCH"`) only matches on an identical branch name, so it could never fire across days.

Dropping the date makes the branch stable per version: the force-push updates the existing branch and `gh pr edit` refreshes the open PR body instead of stacking duplicates. The run date still lands in the file contents via `set_version.py`, so the PR stays current.