### PR TITLE
fix(ci): Docker publish never fires — dispatch it explicitly and keep uv.lock in sync

### DIFF
--- a/.github/workflows/release-on-spec.yml
+++ b/.github/workflows/release-on-spec.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: write   # dispatch publish.yml after cutting the release
 
 concurrency:
   group: release-on-spec
@@ -56,3 +57,7 @@ jobs:
             --title "$TITLE" \
             --notes-file /tmp/notes.md \
             --latest
+
+          # Releases created with GITHUB_TOKEN don't fire `release:` triggers
+          # (recursion guard), so publish.yml must be dispatched explicitly.
+          gh workflow run publish.yml --ref main

--- a/.github/workflows/update-spec.yml
+++ b/.github/workflows/update-spec.yml
@@ -81,6 +81,9 @@ jobs:
           DATE="$(date -u +%Y-%m-%d)"
           TOOLS="$(python -c "import json;from better_mealie_mcp.naming import build_names;print(len(build_names(json.load(open('openapi.json')))))")"
           python scripts/set_version.py "$MEALIE_VERSION" "$DATE" "$TOOLS"
+          # set_version bumps pyproject's version; re-lock so `uv sync --locked`
+          # (Docker build) keeps working.
+          pip install uv && uv lock
           python scripts/spec_diff.py /tmp/old-spec.json openapi.json > /tmp/notes.md
           echo "----- proposed change -----"; cat /tmp/notes.md
 

--- a/uv.lock
+++ b/uv.lock
@@ -68,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "better-mealie-mcp"
-version = "3.20.1"
+version = "3.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Docker images stopped publishing after `3.20.1-r3` — releases **v3.21.0** and **v3.22.0** exist but never produced an image. Two independent bugs:

## 1. `release: published` never triggers publish.yml

`release-on-spec.yml` creates releases with the default `GITHUB_TOKEN`, and GitHub does not fire workflow triggers for events created with that token (recursion guard). So `publish.yml` only ever ran when dispatched by hand.

**Fix:** `workflow_dispatch` is exempt from that guard — after `gh release create` succeeds, dispatch `publish.yml` explicitly (needs `actions: write`). The existing early-exit for already-existing releases correctly skips the dispatch too.

## 2. Stale `uv.lock` breaks the Docker build anyway

`update-spec.yml` bumps `version` in `pyproject.toml` via `set_version.py` but never re-locks, so `uv.lock` still recorded `3.20.1` and `uv sync --locked` in the Dockerfile fails (verified: manual dispatch [run 30342356906](https://github.com/djwmarcx/better-mealie-mcp/actions/runs/30342356906) failed exactly there).

**Fix:** run `uv lock` right after the version bump in `update-spec.yml`, and regenerate the lockfile for the current 3.22.0 in this PR.

## Manual catch-up

`3.22.0` + `latest` published by dispatching `publish.yml` on this branch: [run 30342605869](https://github.com/djwmarcx/better-mealie-mcp/actions/runs/30342605869).